### PR TITLE
mobile menu icon still showed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -444,7 +444,7 @@ textarea:focus {
 /* RESPONSIVE
 /*******************************************/
 
-html body .mobile-icons {
+#mobile-menu {
   display: none
 }
 
@@ -479,7 +479,7 @@ html body .mobile-icons {
 
   /* nav */
 
-  html body .mobile-icons {
+  #mobile-menu {
     display: flex;
     font-size: 35px;
   }

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 							<img src="css/assets/images/feather horizontal bottom middle light.png" alt="logo">
 						</a>
 					</section>
-					<span class="material-symbols-outlined mobile-icons">menu</span>
+					<span id="mobile-menu" class="material-symbols-outlined mobile-icons">menu</span>
 					<ul class="container">
 						<!-- <li><a href="#hero">Home</a></li> -->
 						<li><a href="#about">about</a></li>


### PR DESCRIPTION
mobile menu icon still was showing up on desktop screen size instead of exclusively mobile screen size ugh used an id instead of a class to override the imported class style